### PR TITLE
Feat: Custom API Key

### DIFF
--- a/src/coda.ts
+++ b/src/coda.ts
@@ -20,7 +20,7 @@ export class CodaSDK {
   }
 
   resolveBrowserLink = async (
-    url: string,
+    url: string
   ): Promise<Omit<Page, "tabId"> | ResolveBrowserLinkError> => {
     console.log(`Resolving ${url}`);
 
@@ -68,6 +68,7 @@ export class CodaSDK {
       id,
       name,
       docId,
+      url,
     };
   };
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -18,3 +18,23 @@ export const sendMessage = async <R extends Request>(
 ): Promise<Response<R>> => {
   return await chrome.tabs.sendMessage(tabId, request);
 };
+
+export const getRootPageUrl = (url: string) => {
+  // URL constructor is used to easily parse the URL components
+  // Example URL: https://coda.io/d/Filum-Task-Management_dwiwr75F9kd/Releases_suPXJ-wx#_lu4J7HAD
+  try {
+    const parsedUrl = new URL(url);
+    // Use a regular expression to extract the root URL part, capturing only the base path up to the unique document identifier.
+    // This stops at the first occurrence of any subdirectory or section (like "Releases_suPXJ-wx") that comes after "/d/<document_id>".
+    const regex = /^(.+?\/d\/[^\/]+)/;
+    const match = parsedUrl.href.match(regex);
+    if (match) {
+      return match[1];
+    }
+    // If no match is found, return null or an empty string
+    return null;
+  } catch (error) {
+    console.error('Invalid URL provided:', error);
+    return null;
+  }
+}

--- a/src/common.ts
+++ b/src/common.ts
@@ -14,18 +14,19 @@ export const theme = extendTheme({
 
 export const sendMessage = async <R extends Request>(
   tabId: number,
-  request: R,
+  request: R
 ): Promise<Response<R>> => {
   return await chrome.tabs.sendMessage(tabId, request);
 };
 
 export const getRootPageUrl = (url: string) => {
-  // URL constructor is used to easily parse the URL components
-  // Example URL: https://coda.io/d/Filum-Task-Management_dwiwr75F9kd/Releases_suPXJ-wx#_lu4J7HAD
+  // Parse URL components using URL constructor
+  // Example: converts "https://coda.io/d/document-name_Random-Doc-String/page-name_Random-Page-String"
+  // to "https://coda.io/d/document-name_Random-Doc-String"
   try {
     const parsedUrl = new URL(url);
     // Use a regular expression to extract the root URL part, capturing only the base path up to the unique document identifier.
-    // This stops at the first occurrence of any subdirectory or section (like "Releases_suPXJ-wx") that comes after "/d/<document_id>".
+    // This stops at the first occurrence of any subdirectory or section (like "document-name_Random-Doc-String") that comes after "/d/".
     const regex = /^(.+?\/d\/[^\/]+)/;
     const match = parsedUrl.href.match(regex);
     if (match) {
@@ -34,7 +35,7 @@ export const getRootPageUrl = (url: string) => {
     // If no match is found, return null or an empty string
     return null;
   } catch (error) {
-    console.error('Invalid URL provided:', error);
+    console.error("Invalid URL provided:", error);
     return null;
   }
-}
+};

--- a/src/contexts/page.tsx
+++ b/src/contexts/page.tsx
@@ -9,7 +9,7 @@ import {
 import { CodaSDK } from "@/coda.ts";
 import { Page } from "@/schemas.ts";
 
-import { useSettings } from "./settings.tsx";
+import { useSettings, getTokenForUrl } from "./settings.tsx";
 
 interface Error {
   message: string;
@@ -58,7 +58,14 @@ export const PageProvider = ({ children }: PageProviderProps) => {
       const tabUrl = tab.url;
       const tabId = tab.id;
 
-      const codaSdk = new CodaSDK(settings.token);
+      const token = getTokenForUrl(settings, tabUrl);
+      if (!token) {
+        chrome.runtime.openOptionsPage();
+        window.close();
+        return;
+      }
+
+      const codaSdk = new CodaSDK(token);
       const result = await codaSdk.resolveBrowserLink(tabUrl);
 
       setIsFetched(true);

--- a/src/contexts/page.tsx
+++ b/src/contexts/page.tsx
@@ -58,14 +58,7 @@ export const PageProvider = ({ children }: PageProviderProps) => {
       const tabUrl = tab.url;
       const tabId = tab.id;
 
-      const token = getTokenForUrl(settings, tabUrl);
-      if (!token) {
-        chrome.runtime.openOptionsPage();
-        window.close();
-        return;
-      }
-
-      const codaSdk = new CodaSDK(token);
+      const codaSdk = new CodaSDK(getTokenForUrl(settings, tabUrl));
       const result = await codaSdk.resolveBrowserLink(tabUrl);
 
       setIsFetched(true);

--- a/src/contexts/settings.tsx
+++ b/src/contexts/settings.tsx
@@ -92,7 +92,7 @@ export const getTokenForUrl = (settings: SettingsData, url: string): string => {
 
   // First, check if there's a custom token for the exact URL
   const customToken = settings.customTokens?.find(
-    (custom) => new URL(custom.docUrl).origin === new URL(rootPageUrl).origin
+    (custom) => custom.docUrl === rootPageUrl
   );
 
   // If custom token found, return it

--- a/src/contexts/settings.tsx
+++ b/src/contexts/settings.tsx
@@ -87,8 +87,6 @@ export const useSettings = (): SettingsContextValue => {
 };
 
 export const getTokenForUrl = (settings: SettingsData, url: string): string => {
-  if (!settings || !url) return settings.token;
-
   const rootPageUrl = getRootPageUrl(url);
   if (!rootPageUrl) return settings.token;
 

--- a/src/contexts/settings.tsx
+++ b/src/contexts/settings.tsx
@@ -87,19 +87,15 @@ export const useSettings = (): SettingsContextValue => {
 };
 
 export const getTokenForUrl = (settings: SettingsData, url: string): string => {
-  console.log("Calling getTokenForUrl:", settings, url);
   if (!settings || !url) return settings.token;
 
   const rootPageUrl = getRootPageUrl(url);
   if (!rootPageUrl) return settings.token;
 
-  console.log("Root page URL:", rootPageUrl);
-
   // First, check if there's a custom token for the exact URL
   const customToken = settings.customTokens?.find(
     (custom) => new URL(custom.docUrl).origin === new URL(rootPageUrl).origin
   );
-  console.log("Found custom token:", customToken);
 
   // If custom token found, return it
   if (customToken) return customToken.token;

--- a/src/popup/Actions/CreateSubpage.tsx
+++ b/src/popup/Actions/CreateSubpage.tsx
@@ -13,7 +13,7 @@ import { z } from "zod";
 
 import { sendMessage } from "@/common.ts";
 import { usePage } from "@/contexts/page.tsx";
-import { useSettings } from "@/contexts/settings.tsx";
+import { useSettings, getTokenForUrl } from "@/contexts/settings.tsx";
 import {
   CreateSubpageRequest,
   iconSchema,
@@ -60,7 +60,7 @@ export const CreateSubpage = () => {
 
     const response = await sendMessage<CreateSubpageRequest>(page.tabId, {
       type: RequestType.CREATE_SUBPAGE,
-      token: settings.token,
+      token: getTokenForUrl(settings, page.url),
       docId: page.docId,
       parentPageId: page.id,
       ...values,

--- a/src/popup/Actions/DeletePage.tsx
+++ b/src/popup/Actions/DeletePage.tsx
@@ -10,7 +10,7 @@ import { useForm } from "react-hook-form";
 
 import { sendMessage } from "@/common.ts";
 import { usePage } from "@/contexts/page.tsx";
-import { useSettings } from "@/contexts/settings.tsx";
+import { useSettings, getTokenForUrl } from "@/contexts/settings.tsx";
 import { DeletePageRequest, RequestType, ResponseType } from "@/schemas.ts";
 
 export const DeletePage = () => {
@@ -37,7 +37,7 @@ export const DeletePage = () => {
 
     const response = await sendMessage<DeletePageRequest>(page.tabId, {
       type: RequestType.DELETE_PAGE,
-      token: settings.token,
+      token: getTokenForUrl(settings, page.url),
       docId: page.docId,
       pageId: page.id,
     });

--- a/src/popup/Actions/UpdatePage.tsx
+++ b/src/popup/Actions/UpdatePage.tsx
@@ -13,7 +13,7 @@ import { z } from "zod";
 
 import { sendMessage } from "@/common.ts";
 import { usePage } from "@/contexts/page.tsx";
-import { useSettings } from "@/contexts/settings.tsx";
+import { useSettings, getTokenForUrl } from "@/contexts/settings.tsx";
 import {
   iconSchema,
   RequestType,
@@ -65,7 +65,7 @@ export const UpdatePage = () => {
 
     const response = await sendMessage<UpdatePageRequest>(page.tabId, {
       type: RequestType.UPDATE_PAGE,
-      token: settings.token,
+      token: getTokenForUrl(settings, page.url),
       docId: page.docId,
       pageId: page.id,
       ...values,

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -1,4 +1,11 @@
-import { Center, Container, Spinner, Text, VStack } from "@chakra-ui/react";
+import {
+  Center,
+  Container,
+  Spinner,
+  Text,
+  VStack,
+  Button,
+} from "@chakra-ui/react";
 
 import { usePage } from "@/contexts/page.tsx";
 
@@ -21,11 +28,19 @@ export const Popup = () => {
 
     if (error) {
       return (
-        <Center flexGrow={1}>
-          <Text width="75%" align="center">
-            {`Cannot fetch page data from the current tab. ${error.message}`}
-          </Text>
-        </Center>
+        <VStack spacing={4} width="100%" p={4}>
+          <Center flexGrow={1}>
+            <Text width="75%" align="center">
+              {`Cannot fetch page data from the current tab. ${error.message}`}
+            </Text>
+          </Center>
+          <Button
+            colorScheme="blue"
+            onClick={() => chrome.runtime.openOptionsPage()}
+          >
+            Go to Settings
+          </Button>
+        </VStack>
       );
     }
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -5,6 +5,7 @@ export interface Page {
   name: string;
   docId: string;
   tabId: number;
+  url: string;
 }
 
 export const iconSchema = z.object({

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -33,6 +33,9 @@ import {
 export const Settings = () => {
   const { settings, isFetched } = useSettings();
 
+  const [showDefaultToken, setShowDefaultToken] = useBoolean();
+  const [showCustomTokens, setShowCustomTokens] = useState<boolean[]>([]);
+
   const {
     handleSubmit,
     register,
@@ -55,8 +58,13 @@ export const Settings = () => {
   useEffect(() => {
     if (isFetched && settings) {
       reset(settings);
+
+      // Initialize showCustomTokens when settings are fetched
+      if (settings.customTokens?.length) {
+        setShowCustomTokens(settings.customTokens.map(() => false));
+      }
     }
-  }, [isFetched, reset, settings]);
+  }, [isFetched, reset, settings, setShowCustomTokens]);
 
   const toast = useToast();
 
@@ -85,9 +93,6 @@ export const Settings = () => {
     window.location.reload();
   };
 
-  const [showDefaultToken, setShowDefaultToken] = useBoolean();
-  const [showCustomTokens, setShowCustomTokens] = useState<boolean[]>([]);
-
   return (
     <Container maxW="container.md" py={8}>
       <form onSubmit={handleSubmit(onSubmit)}>
@@ -103,7 +108,9 @@ export const Settings = () => {
 
           {/* Default Token */}
           <FormControl isInvalid={!!errors.token}>
-            <FormLabel>Default API Key</FormLabel>
+            <Heading size="md" mb={4}>
+              Default API Key
+            </Heading>
             <InputGroup>
               <Input
                 {...register("token")}

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -18,7 +18,7 @@ import {
   Box,
 } from "@chakra-ui/react";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useForm, useFieldArray } from "react-hook-form";
 import { FaRegEye, FaRegEyeSlash, FaTrash, FaPlus } from "react-icons/fa";
 
@@ -83,6 +83,7 @@ export const Settings = () => {
   };
 
   const [showDefaultToken, setShowDefaultToken] = useBoolean();
+  const [showCustomTokens, setShowCustomTokens] = useState<boolean[]>([]);
 
   return (
     <Container maxW="container.md" py={8}>
@@ -126,7 +127,10 @@ export const Settings = () => {
               <Heading size="md">Custom Document Tokens</Heading>
               <Button
                 leftIcon={<FaPlus />}
-                onClick={() => append({ docUrl: "", token: "" })}
+                onClick={() => {
+                  setShowCustomTokens((prev) => [...prev, false]);
+                  append({ docUrl: "", token: "" });
+                }}
                 colorScheme="blue"
                 variant="outline"
               >
@@ -145,7 +149,9 @@ export const Settings = () => {
                 mb={4}
               >
                 <FormControl isInvalid={!!errors.customTokens?.[index]?.docUrl}>
-                  <FormLabel>Document URL</FormLabel>
+                  <FormLabel>
+                    Document URL (Any page URL within the document)
+                  </FormLabel>
                   <Input
                     {...register(`customTokens.${index}.docUrl`)}
                     placeholder="https://example.com/docs"
@@ -162,16 +168,29 @@ export const Settings = () => {
                   <InputGroup>
                     <Input
                       {...register(`customTokens.${index}.token`)}
-                      type="password"
+                      type={showCustomTokens[index] ? "text" : "password"}
                       placeholder="Enter custom API token"
                     />
                     <InputRightElement>
                       <IconButton
                         variant="ghost"
-                        aria-label="Remove Custom Token"
-                        icon={<FaTrash />}
-                        onClick={() => remove(index)}
-                        colorScheme="red"
+                        aria-label={
+                          showCustomTokens[index] ? "Hide token" : "Show token"
+                        }
+                        icon={
+                          showCustomTokens[index] ? (
+                            <FaRegEyeSlash />
+                          ) : (
+                            <FaRegEye />
+                          )
+                        }
+                        onClick={() =>
+                          setShowCustomTokens((prev) =>
+                            prev.map((value, i) =>
+                              i === index ? !value : value
+                            )
+                          )
+                        }
                       />
                     </InputRightElement>
                   </InputGroup>
@@ -181,6 +200,22 @@ export const Settings = () => {
                     </FormErrorMessage>
                   )}
                 </FormControl>
+
+                <Button
+                  leftIcon={<FaTrash />}
+                  onClick={() => {
+                    setShowCustomTokens((prev) =>
+                      prev.filter((_, i) => i !== index)
+                    );
+                    remove(index);
+                  }}
+                  colorScheme="red"
+                  variant="outline"
+                  alignSelf="flex-start"
+                  mb={4}
+                >
+                  Remove Custom Token
+                </Button>
               </VStack>
             ))}
           </Box>

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -80,6 +80,9 @@ export const Settings = () => {
     });
 
     reset(values);
+
+    // Reload the page content to reflect the transformed settings
+    window.location.reload();
   };
 
   const [showDefaultToken, setShowDefaultToken] = useBoolean();
@@ -100,12 +103,12 @@ export const Settings = () => {
 
           {/* Default Token */}
           <FormControl isInvalid={!!errors.token}>
-            <FormLabel>Default API Token</FormLabel>
+            <FormLabel>Default API Key</FormLabel>
             <InputGroup>
               <Input
                 {...register("token")}
                 type={showDefaultToken ? "text" : "password"}
-                placeholder="Enter your default API token"
+                placeholder="Enter your default API Key"
               />
               <InputRightElement>
                 <IconButton
@@ -124,7 +127,7 @@ export const Settings = () => {
           {/* Custom Tokens */}
           <Box>
             <HStack justifyContent="space-between" mb={4}>
-              <Heading size="md">Custom Document Tokens</Heading>
+              <Heading size="md">Custom Document Keys</Heading>
               <Button
                 leftIcon={<FaPlus />}
                 onClick={() => {
@@ -164,12 +167,12 @@ export const Settings = () => {
                 </FormControl>
 
                 <FormControl isInvalid={!!errors.customTokens?.[index]?.token}>
-                  <FormLabel>Custom API Token</FormLabel>
+                  <FormLabel>Document API Key</FormLabel>
                   <InputGroup>
                     <Input
                       {...register(`customTokens.${index}.token`)}
                       type={showCustomTokens[index] ? "text" : "password"}
-                      placeholder="Enter custom API token"
+                      placeholder="Enter document API Key"
                     />
                     <InputRightElement>
                       <IconButton
@@ -214,7 +217,7 @@ export const Settings = () => {
                   alignSelf="flex-start"
                   mb={4}
                 >
-                  Remove Custom Token
+                  Remove Custom Key
                 </Button>
               </VStack>
             ))}

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -144,7 +144,7 @@ export const Settings = () => {
                 colorScheme="blue"
                 variant="outline"
               >
-                Add Custom Token
+                Add Custom Key
               </Button>
             </HStack>
 


### PR DESCRIPTION
Summary of changes:
- Allow the user to configure individual API keys for each Coda document.
- Add Go to Settings button if cannot fetch page data from the current tab
<img width="1790" alt="Screenshot 2024-12-22 at 03 09 10" src="https://github.com/user-attachments/assets/78354c87-7c24-4b64-bcd9-271ff6fc12b1" />
